### PR TITLE
Fix scouting breaking when reloading the raid from the inside stairs

### DIFF
--- a/src/main/java/com/lowdetailchambers/LowDetailChambersPlugin.java
+++ b/src/main/java/com/lowdetailchambers/LowDetailChambersPlugin.java
@@ -73,7 +73,7 @@ public class LowDetailChambersPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		if (event.getVarbitId() == Varbits.IN_RAID || event.getVarpId() == VarPlayer.IN_RAID_PARTY)
+		if (event.getVarbitId() == Varbits.IN_RAID || event.getVarpId() == VarPlayer.IN_RAID_PARTY || event.getVarbitId() == Varbits.RAID_STATE)
 		{
 			if (!lowDetailDisabled())
 			{
@@ -91,9 +91,31 @@ public class LowDetailChambersPlugin extends Plugin
 
 	private boolean insideChambersOfXeric()
 	{
+		if (client.getVarbitValue(Varbits.IN_RAID) != 1)
+		{
+			// Not inside the lobby or the raid levels.
+			return false;
+		}
+
 		int raidPartyID = client.getVarpValue(VarPlayer.IN_RAID_PARTY);
-		boolean inRaidChambers = client.getVarbitValue(Varbits.IN_RAID) == 1;
-		return raidPartyID != -1 && inRaidChambers;
+		if (raidPartyID == -1)
+		{
+			// Raid party ID is -1 when:
+			// 1. We're not in a raid party at all (e.g. outside the raid)
+			// 2. We were in a party but we're currently reloading the raid from the inside stairs
+			// 3. We were in a party but then we started the raid
+			//
+			// Only #3 is a valid reason to enable low detail mode. The other two cases should NOT result
+			// in toggling low detail.
+
+			// The plugin crashes if we check RAID_STATE while not inside Chambers, so only check
+			// RAID_STATE here now that we know it's safe.
+			int raidState = client.getVarbitValue(Varbits.RAID_STATE);
+			return raidState != 0 && raidState != 5;
+		}
+
+		// We're in the lobby, we haven't started the raid, and we're not currently reloading the raid.
+		return true;
 	}
 
 	private boolean lowDetailDisabled()


### PR DESCRIPTION
The recent CoX changes made it possible to reload the raid from the inside stairs, but if this plugin is enabled, it breaks Runelite's Raids plugin and prevents the scouting overlay from updating correctly. This is because whenever we call `client.changeMemoryMode(true/false)`, it _always_ causes the `GameState` to briefly change from `LOGGED_IN` to `LOADING`, which interferes with the Raids plugin that will also respond to the `onVarbitChanged()` event on the current client tick.

I ran into this issue with my own plugin: https://github.com/bepzi/runelite-plugins/issues/2 and this PR is my solution to the problem:
1. We store a boolean tracking whether or not low detail mode is active so that we can avoid calling `client.changeMemoryMode()` unless we absolutely have to
2. Change the logic for determining whether or not we're inside CoX to check both the `IN_RAID`  Varbit, the `RAID_STATE` Varbit, and the `IN_RAID_PARTY` Varp, and only if all of them are valid will we try to change the memory mode. Reloading a raid from the CoX lobby will briefly reset the `IN_RAID_PARTY` Varp but not the `IN_RAID` Varbit. Only once both variables are properly set is it safe to call `client.changeMemoryMode()`.